### PR TITLE
Release v0.1.0

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -39,7 +39,7 @@ jobs:
       run: |
         [ "v${{ steps.package_version.outputs.version }}" = "${{ github.ref_name }}" ]
     - name: check changelog includes version
-      run: grep ${{ github.ref_name }} < CHANGELOG.md
+      run: grep '## \[${{ steps.package_version.outputs.version }}\]' < CHANGELOG.md
 
   publish:
     runs-on: ubuntu-24.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.1.0] - 2024-07-11
+
+The first release of this package.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,3 +100,29 @@ edit `pyproject.toml` and then run the `uv pip compile`.
 
 Development dependency versions are upgraded automatically
 by [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates)
+
+## Publishing
+
+This package is built and uploaded to PyPI automatically
+by the `build_and_publish` workflow
+in GitHub Actions.
+This workflow will be run whenever a tag is pushed for a new version;
+the tag must start with `v`.
+
+To publish a new version of this package:
+
+1. Update the version in `pyproject.toml`.
+2. Check all changes have been recorded in [the changelog](./CHANGELOG.md).
+3. Add a heading for the new version,
+   including today's date.
+4. Commit the changes and open a PR.
+5. Tag the merge commit with the new version:
+
+   ```sh
+   git tag 'v0.0.0'
+   git push origin --tags
+   ```
+
+The `build_and_publish` workflow will verify
+that the tag, package version, and changelog
+all contain the same version number.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ where = ["src"]
 
 [project]
 name = "datetime_tools"
-version = "0.0.0"
+version = "0.1.0"
 description = "Tools for working with timezone-aware datetimes."
 license.file = "LICENSE"
 readme = "README.md"


### PR DESCRIPTION
- **Update `verify` job to check for version number, not tag**
- **Add documentation for publishing the package**
- **v0.1.0**
