### PR TITLE
Run `coverage` in parallel mode

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 min_version = 4.0
-envlist = py310,py311,py312
+envlist = py310,py311,py312,report
 
 [testenv]
 # Install wheels instead of source distributions for faster execution.
@@ -10,6 +10,16 @@ wheel_build_env = .pkg
 
 deps = -rrequirements.txt
 commands =
+  coverage run --parallel-mode -m pytest {posargs:tests}
+
+[testenv:clean]
+skip_install = true
+commands =
   coverage erase
-  coverage run -m pytest {posargs:tests}
+
+[testenv:report]
+skip_install = true
+depends = py310,py311,py312
+commands =
+  coverage combine
   coverage report


### PR DESCRIPTION
This avoids problems that occur when multiple test runs try to record
coverage information at the same time. Instead, we record coverage data
independently for each run and combine and report them in a separate
step.
